### PR TITLE
kick,mute: return error

### DIFF
--- a/client/group_info.go
+++ b/client/group_info.go
@@ -316,17 +316,24 @@ func (m *GroupMemberInfo) EditSpecialTitle(title string) {
 	}
 }
 
-func (m *GroupMemberInfo) Kick(msg string, block bool) {
+func (m *GroupMemberInfo) Kick(msg string, block bool) error {
 	if m.Uin != m.Group.client.Uin && m.Manageable() {
 		m.Group.client.kickGroupMember(m.Group.Code, m.Uin, msg, block)
+		return nil
+	} else {
+		return errors.New("not manageable")
 	}
 }
 
-func (m *GroupMemberInfo) Mute(time uint32) {
+func (m *GroupMemberInfo) Mute(time uint32) error {
+	if time >= 2592000 {
+		return errors.New("time is not in range")
+	}
 	if m.Uin != m.Group.client.Uin && m.Manageable() {
-		if time < 2592000 {
-			m.Group.client.groupMute(m.Group.Code, m.Uin, time)
-		}
+		m.Group.client.groupMute(m.Group.Code, m.Uin, time)
+		return nil
+	} else {
+		return errors.New("not manageable")
 	}
 }
 


### PR DESCRIPTION
减少http/ws调用次数

原处理流程：
1. 消息处理端通过http/ws调用getGroupMemberInfo获取自身权限（多1次调用），对方权限在event中已有
2. 检查权限是否足够，如果权限不够提示
3. 进行处理 踢人/禁言

修改后处理流程
1. 直接处理 踢人/禁言
2. 根据错误进行提示