### PR TITLE
chore: bump to go1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mrs4s/MiraiGo
 
-go 1.15
+go 1.16
 
 require (
 	github.com/golang/protobuf v1.4.3


### PR DESCRIPTION
因为用了go1.16的特性