### PR TITLE
确保未出错时才尝试调用body.Close()

### DIFF
--- a/utils/http.go
+++ b/utils/http.go
@@ -20,10 +20,10 @@ var client = &http.Client{
 // HttpGetBytes 带 cookie 的 GET 请求
 func HttpGetBytes(url, cookie string) ([]byte, error) {
 	body, err := HTTPGetReadCloser(url, cookie)
-	defer func() { _ = body.Close() }()
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = body.Close() }()
 	return io.ReadAll(body)
 }
 


### PR DESCRIPTION
原先的写法会导致在出错时也会尝试调用body.Close，此时body为nil，导致panic。
调整顺序可以解决这个问题

![Snipaste_2021-10-21_10-10-54](https://user-images.githubusercontent.com/13483212/138199172-e0096e32-c954-424d-b996-598ef24443a5.png)
![QQ图片20211021101058](https://user-images.githubusercontent.com/13483212/138199180-11c53752-bd55-4700-a17d-196b80e100c7.png)

