### PR TITLE
perf(writer): more OpenWriterF to optimize mem use

### DIFF
--- a/binary/writer.go
+++ b/binary/writer.go
@@ -112,6 +112,12 @@ func (w *Writer) WriteBytesShort(data []byte) {
 	w.Write(data)
 }
 
+func (w *Writer) WriteBytesShortAndClose(data []byte, cl func()) {
+	w.WriteUInt16(uint16(len(data)))
+	w.Write(data)
+	cl()
+}
+
 func (w *Writer) WriteTlvLimitedSize(data []byte, limit int) {
 	if len(data) <= limit {
 		w.WriteBytesShort(data)

--- a/binary/writer.go
+++ b/binary/writer.go
@@ -30,6 +30,11 @@ func (w *Writer) Write(b []byte) {
 	(*bytes.Buffer)(w).Write(b)
 }
 
+func (w *Writer) WriteAndClose(b []byte, cl func()) {
+	(*bytes.Buffer)(w).Write(b)
+	cl()
+}
+
 func (w *Writer) WriteHex(h string) {
 	b, _ := hex.DecodeString(h)
 	w.Write(b)
@@ -114,8 +119,7 @@ func (w *Writer) WriteBytesShort(data []byte) {
 
 func (w *Writer) WriteBytesShortAndClose(data []byte, cl func()) {
 	w.WriteUInt16(uint16(len(data)))
-	w.Write(data)
-	cl()
+	w.WriteAndClose(data, cl)
 }
 
 func (w *Writer) WriteTlvLimitedSize(data []byte, limit int) {

--- a/binary/writer.go
+++ b/binary/writer.go
@@ -15,7 +15,7 @@ func NewWriterF(f func(writer *Writer)) []byte {
 	w := SelectWriter()
 	f(w)
 	b := append([]byte(nil), w.Bytes()...)
-	PutWriter(w)
+	w.putback()
 	return b
 }
 
@@ -23,7 +23,7 @@ func NewWriterF(f func(writer *Writer)) []byte {
 func OpenWriterF(f func(*Writer)) (b []byte, cl func()) {
 	w := SelectWriter()
 	f(w)
-	return w.Bytes(), func() { PutWriter(w) }
+	return w.Bytes(), w.putback
 }
 
 func (w *Writer) Write(b []byte) {
@@ -144,4 +144,8 @@ func (w *Writer) Reset() {
 
 func (w *Writer) Grow(n int) {
 	(*bytes.Buffer)(w).Grow(n)
+}
+
+func (w *Writer) putback() {
+	PutWriter(w)
 }

--- a/client/builders.go
+++ b/client/builders.go
@@ -37,14 +37,14 @@ func (c *QQClient) buildLoginPacket() (uint16, []byte) {
 			w.WriteUInt16(0x16)
 		}
 
-		w.Write(tlv.T18(16, uint32(c.Uin)))
-		w.Write(tlv.T1(uint32(c.Uin), c.deviceInfo.IpAddress))
-		w.Write(tlv.T106(uint32(c.Uin), 0, c.version.AppId, c.version.SSOVersion, c.PasswordMd5, true, c.deviceInfo.Guid, c.deviceInfo.TgtgtKey, 0))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
-		w.Write(tlv.T100(c.version.SSOVersion, c.version.SubAppId, c.version.MainSigMap))
-		w.Write(tlv.T107(0))
-		w.Write(tlv.T142(c.version.ApkId))
-		w.Write(tlv.T144(
+		w.WriteAndClose(tlv.T18(16, uint32(c.Uin)))
+		w.WriteAndClose(tlv.T1(uint32(c.Uin), c.deviceInfo.IpAddress))
+		w.WriteAndClose(tlv.T106(uint32(c.Uin), 0, c.version.AppId, c.version.SSOVersion, c.PasswordMd5, true, c.deviceInfo.Guid, c.deviceInfo.TgtgtKey, 0))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T100(c.version.SSOVersion, c.version.SubAppId, c.version.MainSigMap))
+		w.WriteAndClose(tlv.T107(0))
+		w.WriteAndClose(tlv.T142(c.version.ApkId))
+		w.WriteAndClose(tlv.T144(
 			[]byte(c.deviceInfo.IMEI),
 			c.deviceInfo.GenDeviceInfoData(),
 			c.deviceInfo.OSType,
@@ -58,40 +58,41 @@ func (c *QQClient) buildLoginPacket() (uint16, []byte) {
 			c.deviceInfo.TgtgtKey,
 		))
 
-		w.Write(tlv.T145(c.deviceInfo.Guid))
-		w.Write(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
+		w.WriteAndClose(tlv.T145(c.deviceInfo.Guid))
+		w.WriteAndClose(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
 		/*
 			if (miscBitMap & 0x80) != 0{
-				w.Write(tlv.T166(1))
+				w.WriteAndClose(tlv.T166(1))
 			}
 		*/
-		w.Write(tlv.T154(seq))
-		w.Write(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T511([]string{
+		w.WriteAndClose(tlv.T154(seq))
+		w.WriteAndClose(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T511([]string{
 			"tenpay.com", "openmobile.qq.com", "docs.qq.com", "connect.qq.com",
 			"qzone.qq.com", "vip.qq.com", "gamecenter.qq.com", "qun.qq.com", "game.qq.com",
 			"qqweb.qq.com", "office.qq.com", "ti.qq.com", "mail.qq.com", "mma.qq.com",
 		}))
 
-		w.Write(tlv.T187(c.deviceInfo.MacAddress))
-		w.Write(tlv.T188(c.deviceInfo.AndroidId))
+		w.WriteAndClose(tlv.T187(c.deviceInfo.MacAddress))
+		w.WriteAndClose(tlv.T188(c.deviceInfo.AndroidId))
 		if len(c.deviceInfo.IMSIMd5) != 0 {
-			w.Write(tlv.T194(c.deviceInfo.IMSIMd5))
+			w.WriteAndClose(tlv.T194(c.deviceInfo.IMSIMd5))
 		}
 		if c.AllowSlider {
-			w.Write(tlv.T191(0x82))
+			w.WriteAndClose(tlv.T191(0x82))
 		}
 		if len(c.deviceInfo.WifiBSSID) != 0 && len(c.deviceInfo.WifiSSID) != 0 {
-			w.Write(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
+			w.WriteAndClose(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
 		}
-		w.Write(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
-		w.Write(tlv.T516())
-		w.Write(tlv.T521(0))
-		w.Write(tlv.T525(tlv.T536([]byte{0x01, 0x00})))
+		w.WriteAndClose(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
+		w.WriteAndClose(tlv.T516())
+		w.WriteAndClose(tlv.T521(0))
+		w.WriteAndClose(tlv.T525(tlv.T536([]byte{0x01, 0x00})))
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -101,13 +102,14 @@ func (c *QQClient) buildDeviceLockLoginPacket() (uint16, []byte) {
 		w.WriteUInt16(20)
 		w.WriteUInt16(4)
 
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T104(c.t104))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
-		w.Write(tlv.T401(c.g))
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T104(c.t104))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T401(c.g))
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -117,7 +119,7 @@ func (c *QQClient) buildQRCodeFetchRequestPacket() (uint16, []byte) {
 	req := packets.BuildOicqRequestPacket(0, 0x812, c.ecdh, c.RandomKey, func(w *binary.Writer) {
 		w.WriteHex(`0001110000001000000072000000`) // trans header
 		w.WriteUInt32(uint32(time.Now().Unix()))
-		w.Write(packets.BuildCode2DRequestPacket(0, 0, 0x31, func(w *binary.Writer) {
+		w.WriteAndClose(packets.BuildCode2DRequestPacket(0, 0, 0x31, func(w *binary.Writer) {
 			w.WriteUInt16(0)  // const
 			w.WriteUInt32(16) // app id
 			w.WriteUInt64(0)  // const
@@ -125,16 +127,17 @@ func (c *QQClient) buildQRCodeFetchRequestPacket() (uint16, []byte) {
 			w.WriteBytesShort(EmptyBytes)
 
 			w.WriteUInt16(6)
-			w.Write(tlv.T16(watch.SSOVersion, 16, watch.AppId, c.deviceInfo.Guid, []byte(watch.ApkId), []byte(watch.SortVersionName), watch.ApkSign))
-			w.Write(tlv.T1B(0, 0, 3, 4, 72, 2, 2))
-			w.Write(tlv.T1D(watch.MiscBitmap))
-			w.Write(tlv.T1F(false, c.deviceInfo.OSType, []byte("7.1.2"), []byte("China Mobile GSM"), c.deviceInfo.APN, 2))
-			w.Write(tlv.T33(c.deviceInfo.Guid))
-			w.Write(tlv.T35(8))
+			w.WriteAndClose(tlv.T16(watch.SSOVersion, 16, watch.AppId, c.deviceInfo.Guid, []byte(watch.ApkId), []byte(watch.SortVersionName), watch.ApkSign))
+			w.WriteAndClose(tlv.T1B(0, 0, 3, 4, 72, 2, 2))
+			w.WriteAndClose(tlv.T1D(watch.MiscBitmap))
+			w.WriteAndClose(tlv.T1F(false, c.deviceInfo.OSType, []byte("7.1.2"), []byte("China Mobile GSM"), c.deviceInfo.APN, 2))
+			w.WriteAndClose(tlv.T33(c.deviceInfo.Guid))
+			w.WriteAndClose(tlv.T35(8))
 		}))
 	})
-	sso := packets.BuildSsoPacket(seq, watch.AppId, c.version.SubAppId, "wtlogin.trans_emp", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, watch.AppId, c.version.SubAppId, "wtlogin.trans_emp", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(0, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -144,7 +147,7 @@ func (c *QQClient) buildQRCodeResultQueryRequestPacket(sig []byte) (uint16, []by
 	req := packets.BuildOicqRequestPacket(0, 0x812, c.ecdh, c.RandomKey, func(w *binary.Writer) {
 		w.WriteHex(`0000620000001000000072000000`) // trans header
 		w.WriteUInt32(uint32(time.Now().Unix()))
-		w.Write(packets.BuildCode2DRequestPacket(1, 0, 0x12, func(w *binary.Writer) {
+		w.WriteAndClose(packets.BuildCode2DRequestPacket(1, 0, 0x12, func(w *binary.Writer) {
 			w.WriteUInt16(5)  // const
 			w.WriteByte(1)    // const
 			w.WriteUInt32(8)  // product type
@@ -156,8 +159,9 @@ func (c *QQClient) buildQRCodeResultQueryRequestPacket(sig []byte) (uint16, []by
 			w.WriteUInt16(0) // const
 		}))
 	})
-	sso := packets.BuildSsoPacket(seq, watch.AppId, c.version.SubAppId, "wtlogin.trans_emp", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, watch.AppId, c.version.SubAppId, "wtlogin.trans_emp", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(0, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -167,20 +171,20 @@ func (c *QQClient) buildQRCodeLoginPacket(t106, t16a, t318 []byte) (uint16, []by
 		w.WriteUInt16(9)
 		w.WriteUInt16(24)
 
-		w.Write(tlv.T18(16, uint32(c.Uin)))
-		w.Write(tlv.T1(uint32(c.Uin), c.deviceInfo.IpAddress))
+		w.WriteAndClose(tlv.T18(16, uint32(c.Uin)))
+		w.WriteAndClose(tlv.T1(uint32(c.Uin), c.deviceInfo.IpAddress))
 		wb, cl := binary.OpenWriterF(func(bw *binary.Writer) {
 			bw.WriteUInt16(0x106)
 			bw.WriteBytesShort(t106)
 		})
 		w.Write(wb)
 		cl()
-		// w.Write(tlv.T106(uint32(c.Uin), 0, c.version.AppId, c.version.SSOVersion, c.PasswordMd5, true, c.deviceInfo.Guid, c.deviceInfo.TgtgtKey, 0))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
-		w.Write(tlv.T100(c.version.SSOVersion, c.version.SubAppId, c.version.MainSigMap))
-		w.Write(tlv.T107(0))
-		w.Write(tlv.T142(c.version.ApkId))
-		w.Write(tlv.T144(
+		// w.WriteAndClose(tlv.T106(uint32(c.Uin), 0, c.version.AppId, c.version.SSOVersion, c.PasswordMd5, true, c.deviceInfo.Guid, c.deviceInfo.TgtgtKey, 0))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T100(c.version.SSOVersion, c.version.SubAppId, c.version.MainSigMap))
+		w.WriteAndClose(tlv.T107(0))
+		w.WriteAndClose(tlv.T142(c.version.ApkId))
+		w.WriteAndClose(tlv.T144(
 			[]byte(c.deviceInfo.IMEI),
 			c.deviceInfo.GenDeviceInfoData(),
 			c.deviceInfo.OSType,
@@ -194,35 +198,35 @@ func (c *QQClient) buildQRCodeLoginPacket(t106, t16a, t318 []byte) (uint16, []by
 			c.deviceInfo.TgtgtKey,
 		))
 
-		w.Write(tlv.T145(c.deviceInfo.Guid))
-		w.Write(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
+		w.WriteAndClose(tlv.T145(c.deviceInfo.Guid))
+		w.WriteAndClose(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
 		wb, cl = binary.OpenWriterF(func(bw *binary.Writer) {
 			bw.WriteUInt16(0x16A)
 			bw.WriteBytesShort(t16a)
 		})
 		w.Write(wb)
 		cl()
-		w.Write(tlv.T154(seq))
-		w.Write(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T511([]string{
+		w.WriteAndClose(tlv.T154(seq))
+		w.WriteAndClose(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T511([]string{
 			"tenpay.com", "openmobile.qq.com", "docs.qq.com", "connect.qq.com",
 			"qzone.qq.com", "vip.qq.com", "gamecenter.qq.com", "qun.qq.com", "game.qq.com",
 			"qqweb.qq.com", "office.qq.com", "ti.qq.com", "mail.qq.com", "mma.qq.com",
 		}))
-		w.Write(tlv.T187(c.deviceInfo.MacAddress))
-		w.Write(tlv.T188(c.deviceInfo.AndroidId))
+		w.WriteAndClose(tlv.T187(c.deviceInfo.MacAddress))
+		w.WriteAndClose(tlv.T188(c.deviceInfo.AndroidId))
 		if len(c.deviceInfo.IMSIMd5) != 0 {
-			w.Write(tlv.T194(c.deviceInfo.IMSIMd5))
+			w.WriteAndClose(tlv.T194(c.deviceInfo.IMSIMd5))
 		}
-		w.Write(tlv.T191(0x00))
+		w.WriteAndClose(tlv.T191(0x00))
 		if len(c.deviceInfo.WifiBSSID) != 0 && len(c.deviceInfo.WifiSSID) != 0 {
-			w.Write(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
+			w.WriteAndClose(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
 		}
-		w.Write(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
-		w.Write(tlv.T516())
-		w.Write(tlv.T521(8))
-		// w.Write(tlv.T525(tlv.T536([]byte{0x01, 0x00})))
+		w.WriteAndClose(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
+		w.WriteAndClose(tlv.T516())
+		w.WriteAndClose(tlv.T521(8))
+		// w.WriteAndClose(tlv.T525(tlv.T536([]byte{0x01, 0x00})))
 		wb, cl = binary.OpenWriterF(func(bw *binary.Writer) {
 			bw.WriteUInt16(0x318)
 			bw.WriteBytesShort(t318)
@@ -230,8 +234,9 @@ func (c *QQClient) buildQRCodeLoginPacket(t106, t16a, t318 []byte) (uint16, []by
 		w.Write(wb)
 		cl()
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -241,13 +246,14 @@ func (c *QQClient) buildCaptchaPacket(result string, sign []byte) (uint16, []byt
 		w.WriteUInt16(2) // sub command
 		w.WriteUInt16(4)
 
-		w.Write(tlv.T2(result, sign))
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T104(c.t104))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T2(result, sign))
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T104(c.t104))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -257,15 +263,16 @@ func (c *QQClient) buildSMSRequestPacket() (uint16, []byte) {
 		w.WriteUInt16(8)
 		w.WriteUInt16(6)
 
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T104(c.t104))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
-		w.Write(tlv.T174(c.t174))
-		w.Write(tlv.T17A(9))
-		w.Write(tlv.T197())
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T104(c.t104))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T174(c.t174))
+		w.WriteAndClose(tlv.T17A(9))
+		w.WriteAndClose(tlv.T197())
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -275,16 +282,17 @@ func (c *QQClient) buildSMSCodeSubmitPacket(code string) (uint16, []byte) {
 		w.WriteUInt16(7)
 		w.WriteUInt16(7)
 
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T104(c.t104))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
-		w.Write(tlv.T174(c.t174))
-		w.Write(tlv.T17C(code))
-		w.Write(tlv.T401(c.g))
-		w.Write(tlv.T198())
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T104(c.t104))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T174(c.t174))
+		w.WriteAndClose(tlv.T17C(code))
+		w.WriteAndClose(tlv.T401(c.g))
+		w.WriteAndClose(tlv.T198())
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -294,13 +302,14 @@ func (c *QQClient) buildTicketSubmitPacket(ticket string) (uint16, []byte) {
 		w.WriteUInt16(2)
 		w.WriteUInt16(4)
 
-		w.Write(tlv.T193(ticket))
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T104(c.t104))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T193(ticket))
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T104(c.t104))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.login", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -310,19 +319,19 @@ func (c *QQClient) buildRequestTgtgtNopicsigPacket() (uint16, []byte) {
 		w.WriteUInt16(15)
 		w.WriteUInt16(24)
 
-		w.Write(tlv.T18(16, uint32(c.Uin)))
-		w.Write(tlv.T1(uint32(c.Uin), c.deviceInfo.IpAddress))
+		w.WriteAndClose(tlv.T18(16, uint32(c.Uin)))
+		w.WriteAndClose(tlv.T1(uint32(c.Uin), c.deviceInfo.IpAddress))
 		wb, cl := binary.OpenWriterF(func(bw *binary.Writer) {
 			bw.WriteUInt16(0x106)
 			bw.WriteBytesShort(c.sigInfo.encryptedA1)
 		})
 		w.Write(wb)
 		cl()
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
-		w.Write(tlv.T100(c.version.SSOVersion, 2, c.version.MainSigMap))
-		w.Write(tlv.T107(0))
-		w.Write(tlv.T108(c.ksid))
-		w.Write(tlv.T144(
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T100(c.version.SSOVersion, 2, c.version.MainSigMap))
+		w.WriteAndClose(tlv.T107(0))
+		w.WriteAndClose(tlv.T108(c.ksid))
+		w.WriteAndClose(tlv.T144(
 			c.deviceInfo.AndroidId,
 			c.deviceInfo.GenDeviceInfoData(),
 			c.deviceInfo.OSType,
@@ -335,29 +344,29 @@ func (c *QQClient) buildRequestTgtgtNopicsigPacket() (uint16, []byte) {
 			c.deviceInfo.Brand,
 			c.deviceInfo.TgtgtKey,
 		))
-		w.Write(tlv.T142(c.version.ApkId))
-		w.Write(tlv.T145(c.deviceInfo.Guid))
-		w.Write(tlv.T16A(c.sigInfo.srmToken))
-		w.Write(tlv.T154(seq))
-		w.Write(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T511([]string{
+		w.WriteAndClose(tlv.T142(c.version.ApkId))
+		w.WriteAndClose(tlv.T145(c.deviceInfo.Guid))
+		w.WriteAndClose(tlv.T16A(c.sigInfo.srmToken))
+		w.WriteAndClose(tlv.T154(seq))
+		w.WriteAndClose(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T511([]string{
 			"tenpay.com", "openmobile.qq.com", "docs.qq.com", "connect.qq.com",
 			"qzone.qq.com", "vip.qq.com", "qun.qq.com", "game.qq.com", "qqweb.qq.com",
 			"office.qq.com", "ti.qq.com", "mail.qq.com", "qzone.com", "mma.qq.com",
 		}))
-		w.Write(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
-		w.Write(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
-		w.Write(tlv.T400(c.g, c.Uin, c.deviceInfo.Guid, c.dpwd, 1, 16, c.randSeed))
-		w.Write(tlv.T187(c.deviceInfo.MacAddress))
-		w.Write(tlv.T188(c.deviceInfo.AndroidId))
-		w.Write(tlv.T194(c.deviceInfo.IMSIMd5))
-		w.Write(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
-		w.Write(tlv.T516())
-		w.Write(tlv.T521(0))
-		w.Write(tlv.T525(tlv.T536([]byte{0x01, 0x00})))
+		w.WriteAndClose(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
+		w.WriteAndClose(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
+		w.WriteAndClose(tlv.T400(c.g, c.Uin, c.deviceInfo.Guid, c.dpwd, 1, 16, c.randSeed))
+		w.WriteAndClose(tlv.T187(c.deviceInfo.MacAddress))
+		w.WriteAndClose(tlv.T188(c.deviceInfo.AndroidId))
+		w.WriteAndClose(tlv.T194(c.deviceInfo.IMSIMd5))
+		w.WriteAndClose(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
+		w.WriteAndClose(tlv.T516())
+		w.WriteAndClose(tlv.T521(0))
+		w.WriteAndClose(tlv.T525(tlv.T536([]byte{0x01, 0x00})))
 		// w.Write(tlv.545())
-		w.Write(tlv.T545([]byte(c.deviceInfo.IMEI)))
+		w.WriteAndClose(tlv.T545([]byte(c.deviceInfo.IMEI)))
 	})
 	packet := packets.BuildUniPacket(c.Uin, seq, "wtlogin.exchange_emp", 2, c.OutGoingPacketSessionId, []byte{}, make([]byte, 16), req)
 	return seq, packet
@@ -369,12 +378,12 @@ func (c *QQClient) buildRequestChangeSigPacket() (uint16, []byte) {
 		w.WriteUInt16(11)
 		w.WriteUInt16(17)
 
-		w.Write(tlv.T100(c.version.SSOVersion, 100, c.version.MainSigMap))
-		w.Write(tlv.T10A(c.sigInfo.tgt))
-		w.Write(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
-		w.Write(tlv.T108(c.ksid))
+		w.WriteAndClose(tlv.T100(c.version.SSOVersion, 100, c.version.MainSigMap))
+		w.WriteAndClose(tlv.T10A(c.sigInfo.tgt))
+		w.WriteAndClose(tlv.T116(c.version.MiscBitmap, c.version.SubSigmap))
+		w.WriteAndClose(tlv.T108(c.ksid))
 		h := md5.Sum(c.sigInfo.d2Key)
-		w.Write(tlv.T144(
+		w.WriteAndClose(tlv.T144(
 			c.deviceInfo.AndroidId,
 			c.deviceInfo.GenDeviceInfoData(),
 			c.deviceInfo.OSType,
@@ -387,26 +396,27 @@ func (c *QQClient) buildRequestChangeSigPacket() (uint16, []byte) {
 			c.deviceInfo.Brand,
 			h[:],
 		))
-		w.Write(tlv.T143(c.sigInfo.d2))
-		w.Write(tlv.T142(c.version.ApkId))
-		w.Write(tlv.T154(seq))
-		w.Write(tlv.T18(16, uint32(c.Uin)))
-		w.Write(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
-		w.Write(tlv.T8(2052))
-		w.Write(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
-		w.Write(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
-		w.Write(tlv.T187(c.deviceInfo.MacAddress))
-		w.Write(tlv.T188(c.deviceInfo.AndroidId))
-		w.Write(tlv.T194(c.deviceInfo.IMSIMd5))
-		w.Write(tlv.T511([]string{
+		w.WriteAndClose(tlv.T143(c.sigInfo.d2))
+		w.WriteAndClose(tlv.T142(c.version.ApkId))
+		w.WriteAndClose(tlv.T154(seq))
+		w.WriteAndClose(tlv.T18(16, uint32(c.Uin)))
+		w.WriteAndClose(tlv.T141(c.deviceInfo.SimInfo, c.deviceInfo.APN))
+		w.WriteAndClose(tlv.T8(2052))
+		w.WriteAndClose(tlv.T147(16, []byte(c.version.SortVersionName), c.version.ApkSign))
+		w.WriteAndClose(tlv.T177(c.version.BuildTime, c.version.SdkVersion))
+		w.WriteAndClose(tlv.T187(c.deviceInfo.MacAddress))
+		w.WriteAndClose(tlv.T188(c.deviceInfo.AndroidId))
+		w.WriteAndClose(tlv.T194(c.deviceInfo.IMSIMd5))
+		w.WriteAndClose(tlv.T511([]string{
 			"tenpay.com", "openmobile.qq.com", "docs.qq.com", "connect.qq.com",
 			"qzone.qq.com", "vip.qq.com", "qun.qq.com", "game.qq.com", "qqweb.qq.com",
 			"office.qq.com", "ti.qq.com", "mail.qq.com", "qzone.com", "mma.qq.com",
 		}))
-		// w.Write(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
+		// w.WriteAndClose(tlv.T202(c.deviceInfo.WifiBSSID, c.deviceInfo.WifiSSID))
 	})
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.exchange_emp", c.deviceInfo.IMEI, c.sigInfo.tgt, c.OutGoingPacketSessionId, req, c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "wtlogin.exchange_emp", c.deviceInfo.IMEI, c.sigInfo.tgt, c.OutGoingPacketSessionId, req, c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 2, make([]byte, 16), sso, []byte{})
+	clo()
 	return seq, packet
 }
 
@@ -453,8 +463,9 @@ func (c *QQClient) buildClientRegisterPacket() (uint16, []byte) {
 		Context:      make(map[string]string),
 		Status:       make(map[string]string),
 	}
-	sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "StatSvc.register", c.deviceInfo.IMEI, c.sigInfo.tgt, c.OutGoingPacketSessionId, pkt.ToBytes(), c.ksid)
+	sso, clo := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "StatSvc.register", c.deviceInfo.IMEI, c.sigInfo.tgt, c.OutGoingPacketSessionId, pkt.ToBytes(), c.ksid)
 	packet := packets.BuildLoginPacket(c.Uin, 1, c.sigInfo.d2Key, sso, c.sigInfo.d2)
+	clo()
 	return seq, packet
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -880,8 +880,9 @@ func (c *QQClient) doHeartbeat() {
 	for c.Online {
 		time.Sleep(time.Second * 30)
 		seq := c.nextSeq()
-		sso := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "Heartbeat.Alive", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, []byte{}, c.ksid)
+		sso, cl := packets.BuildSsoPacket(seq, c.version.AppId, c.version.SubAppId, "Heartbeat.Alive", c.deviceInfo.IMEI, []byte{}, c.OutGoingPacketSessionId, []byte{}, c.ksid)
 		packet := packets.BuildLoginPacket(c.Uin, 0, []byte{}, sso, []byte{})
+		cl()
 		_, err := c.sendAndWait(seq, packet)
 		if errors.Is(err, utils.ErrConnectionClosed) {
 			continue

--- a/client/group_info.go
+++ b/client/group_info.go
@@ -156,20 +156,19 @@ func (c *QQClient) buildGroupSearchPacket(keyword string) (uint16, []byte) {
 		},
 		Filtertype: proto.Int32(0),
 	})
+	reqService, cl := binary.OpenWriterF(func(w *binary.Writer) {
+		w.WriteByte(0x28)
+		w.WriteUInt32(uint32(len(comm)))
+		w.WriteUInt32(uint32(len(search)))
+		w.Write(comm)
+		w.Write(search)
+		w.WriteByte(0x29)
+	})
 	req := &jce.SummaryCardReqSearch{
 		Keyword:     keyword,
 		CountryCode: "+86",
 		Version:     3,
-		ReqServices: [][]byte{
-			binary.NewWriterF(func(w *binary.Writer) {
-				w.WriteByte(0x28)
-				w.WriteUInt32(uint32(len(comm)))
-				w.WriteUInt32(uint32(len(search)))
-				w.Write(comm)
-				w.Write(search)
-				w.WriteByte(0x29)
-			}),
-		},
+		ReqServices: [][]byte{reqService},
 	}
 	head := jce.NewJceWriter()
 	head.WriteInt32(2, 0)
@@ -177,6 +176,7 @@ func (c *QQClient) buildGroupSearchPacket(keyword string) (uint16, []byte) {
 		"ReqHead":   packUniRequestData(head.Bytes()),
 		"ReqSearch": packUniRequestData(req.ToBytes()),
 	}}
+	cl()
 	pkt := &jce.RequestPacket{
 		IVersion:     3,
 		SServantName: "SummaryCardServantObj",

--- a/client/qidian.go
+++ b/client/qidian.go
@@ -133,15 +133,17 @@ func (c *QQClient) bigDataRequest(subCmd uint32, req proto.Message) ([]byte, err
 	tea := binary.NewTeaCipher(c.QiDian.bigDataReqSession.SessionKey)
 	body := tea.Encrypt(data)
 	url := fmt.Sprintf("http://%v/cgi-bin/httpconn", c.QiDian.bigDataReqAddrs[0])
-	httpReq, _ := http.NewRequest("POST", url, bytes.NewReader(binary.NewWriterF(func(w *binary.Writer) {
+	postdata, cl := binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteByte(40)
 		w.WriteUInt32(uint32(len(head)))
 		w.WriteUInt32(uint32(len(body)))
 		w.Write(head)
 		w.Write(body)
 		w.WriteByte(41)
-	})))
+	})
+	httpReq, _ := http.NewRequest("POST", url, bytes.NewReader(postdata))
 	rsp, err := http.DefaultClient.Do(httpReq)
+	cl()
 	if err != nil {
 		return nil, errors.Wrap(err, "request error")
 	}

--- a/client/tlv_decoders.go
+++ b/client/tlv_decoders.go
@@ -105,7 +105,13 @@ func (c *QQClient) decodeT119(data, ek []byte) {
 		pt4TokenMap: pt4TokenMap,
 	}
 	if len(c.PasswordMd5[:]) > 0 {
-		key := md5.Sum(append(append(c.PasswordMd5[:], []byte{0x00, 0x00, 0x00, 0x00}...), binary.NewWriterF(func(w *binary.Writer) { w.WriteUInt32(uint32(c.Uin)) })...))
+		data, cl := binary.OpenWriterF(func(w *binary.Writer) {
+			w.Write(c.PasswordMd5[:])
+			w.WriteUInt32(0) // []byte{0x00, 0x00, 0x00, 0x00}...
+			w.WriteUInt32(uint32(c.Uin))
+		})
+		key := md5.Sum(data)
+		cl()
 		decrypted := binary.NewTeaCipher(key[:]).Decrypt(c.sigInfo.encryptedA1)
 		if len(decrypted) > 51+16 {
 			dr := binary.NewReader(decrypted)

--- a/internal/packets/global.go
+++ b/internal/packets/global.go
@@ -54,8 +54,8 @@ func BuildOicqRequestPacket(uin int64, commandId uint16, encrypt IEncryptMethod,
 	})
 }
 
-func BuildCode2DRequestPacket(seq uint32, j uint64, cmd uint16, bodyFunc func(writer *binary.Writer)) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func BuildCode2DRequestPacket(seq uint32, j uint64, cmd uint16, bodyFunc func(writer *binary.Writer)) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		body, cl := binary.OpenWriterF(bodyFunc)
 		w.WriteByte(2)
 		w.WriteUInt16(uint16(43 + len(body) + 1))
@@ -72,8 +72,8 @@ func BuildCode2DRequestPacket(seq uint32, j uint64, cmd uint16, bodyFunc func(wr
 	})
 }
 
-func BuildSsoPacket(seq uint16, appID, subAppID uint32, commandName, imei string, extData, outPacketSessionId, body, ksid []byte) []byte {
-	return binary.NewWriterF(func(p *binary.Writer) {
+func BuildSsoPacket(seq uint16, appID, subAppID uint32, commandName, imei string, extData, outPacketSessionId, body, ksid []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(p *binary.Writer) {
 		p.WriteIntLvPacket(4, func(writer *binary.Writer) {
 			writer.WriteUInt32(uint32(seq))
 			writer.WriteUInt32(appID)

--- a/internal/packets/global.go
+++ b/internal/packets/global.go
@@ -56,7 +56,7 @@ func BuildOicqRequestPacket(uin int64, commandId uint16, encrypt IEncryptMethod,
 
 func BuildCode2DRequestPacket(seq uint32, j uint64, cmd uint16, bodyFunc func(writer *binary.Writer)) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
-		body := binary.NewWriterF(bodyFunc)
+		body, cl := binary.OpenWriterF(bodyFunc)
 		w.WriteByte(2)
 		w.WriteUInt16(uint16(43 + len(body) + 1))
 		w.WriteUInt16(cmd)
@@ -68,6 +68,7 @@ func BuildCode2DRequestPacket(seq uint32, j uint64, cmd uint16, bodyFunc func(wr
 		w.WriteUInt64(j)
 		w.Write(body)
 		w.WriteByte(3)
+		cl()
 	})
 }
 

--- a/internal/tlv/t1.go
+++ b/internal/tlv/t1.go
@@ -7,11 +7,11 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T1(uin uint32, ip []byte) []byte {
+func T1(uin uint32, ip []byte) ([]byte, func()) {
 	if len(ip) != 4 {
 		panic("invalid ip")
 	}
-	return binary.NewWriterF(func(w *binary.Writer) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x01)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)

--- a/internal/tlv/t1.go
+++ b/internal/tlv/t1.go
@@ -13,7 +13,7 @@ func T1(uin uint32, ip []byte) []byte {
 	}
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x01)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)
 			w.WriteUInt32(rand.Uint32())
 			w.WriteUInt32(uin)

--- a/internal/tlv/t100.go
+++ b/internal/tlv/t100.go
@@ -4,8 +4,8 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T100(ssoVersion, protocol, mainSigMap uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T100(ssoVersion, protocol, mainSigMap uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x100)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)

--- a/internal/tlv/t100.go
+++ b/internal/tlv/t100.go
@@ -7,7 +7,7 @@ import (
 func T100(ssoVersion, protocol, mainSigMap uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x100)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)
 			w.WriteUInt32(ssoVersion)
 			w.WriteUInt32(16)

--- a/internal/tlv/t104.go
+++ b/internal/tlv/t104.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T104(data []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T104(data []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x104)
 		w.WriteBytesShort(data)
 	})

--- a/internal/tlv/t106.go
+++ b/internal/tlv/t106.go
@@ -13,7 +13,7 @@ import (
 func T106(uin, salt, appId, ssoVer uint32, passwordMd5 [16]byte, guidAvailable bool, guid, tgtgtKey []byte, wtf uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x106)
-		body := binary.NewWriterF(func(w *binary.Writer) {
+		body, cl := binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(4)
 			w.WriteUInt32(rand.Uint32())
 			w.WriteUInt32(ssoVer)
@@ -43,7 +43,7 @@ func T106(uin, salt, appId, ssoVer uint32, passwordMd5 [16]byte, guidAvailable b
 			w.WriteBytesShort([]byte(strconv.FormatInt(int64(uin), 10)))
 			w.WriteUInt16(0)
 		})
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			b := make([]byte, 4)
 			if salt != 0 {
 				binary2.BigEndian.PutUint32(b, salt)
@@ -53,5 +53,6 @@ func T106(uin, salt, appId, ssoVer uint32, passwordMd5 [16]byte, guidAvailable b
 			key := md5.Sum(append(append(passwordMd5[:], []byte{0x00, 0x00, 0x00, 0x00}...), b...))
 			w.EncryptAndWrite(key[:], body)
 		}))
+		cl()
 	})
 }

--- a/internal/tlv/t106.go
+++ b/internal/tlv/t106.go
@@ -10,8 +10,8 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T106(uin, salt, appId, ssoVer uint32, passwordMd5 [16]byte, guidAvailable bool, guid, tgtgtKey []byte, wtf uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T106(uin, salt, appId, ssoVer uint32, passwordMd5 [16]byte, guidAvailable bool, guid, tgtgtKey []byte, wtf uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x106)
 		body, cl := binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(4)

--- a/internal/tlv/t107.go
+++ b/internal/tlv/t107.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T107(picType uint16) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T107(picType uint16) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x107)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(picType)

--- a/internal/tlv/t107.go
+++ b/internal/tlv/t107.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T107(picType uint16) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x107)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(picType)
 			w.WriteByte(0x00)
 			w.WriteUInt16(0)

--- a/internal/tlv/t108.go
+++ b/internal/tlv/t108.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T108(ksid []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T108(ksid []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x108)
 		w.WriteBytesShort(ksid)
 	})

--- a/internal/tlv/t109.go
+++ b/internal/tlv/t109.go
@@ -9,7 +9,7 @@ import (
 func T109(androidId []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x109)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			h := md5.Sum(androidId)
 			w.Write(h[:])
 		}))

--- a/internal/tlv/t109.go
+++ b/internal/tlv/t109.go
@@ -6,8 +6,8 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T109(androidId []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T109(androidId []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x109)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			h := md5.Sum(androidId)

--- a/internal/tlv/t10a.go
+++ b/internal/tlv/t10a.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T10A(arr []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T10A(arr []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x10A)
 		w.WriteBytesShort(arr)
 	})

--- a/internal/tlv/t116.go
+++ b/internal/tlv/t116.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T116(miscBitmap, subSigMap uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x116)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(0x00)
 			w.WriteUInt32(miscBitmap)
 			w.WriteUInt32(subSigMap)

--- a/internal/tlv/t116.go
+++ b/internal/tlv/t116.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T116(miscBitmap, subSigMap uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T116(miscBitmap, subSigMap uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x116)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(0x00)

--- a/internal/tlv/t124.go
+++ b/internal/tlv/t124.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T124(osType, osVersion, simInfo, apn []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x124)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteTlvLimitedSize(osType, 16)
 			w.WriteTlvLimitedSize(osVersion, 16)
 			w.WriteUInt16(2) // Network type wifi

--- a/internal/tlv/t124.go
+++ b/internal/tlv/t124.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T124(osType, osVersion, simInfo, apn []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T124(osType, osVersion, simInfo, apn []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x124)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteTlvLimitedSize(osType, 16)

--- a/internal/tlv/t128.go
+++ b/internal/tlv/t128.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T128(isGuidFromFileNull, isGuidAvailable, isGuidChanged bool, guidFlag uint32, buildModel, guid, buildBrand []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x128)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)
 			w.WriteBool(isGuidFromFileNull)
 			w.WriteBool(isGuidAvailable)

--- a/internal/tlv/t128.go
+++ b/internal/tlv/t128.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T128(isGuidFromFileNull, isGuidAvailable, isGuidChanged bool, guidFlag uint32, buildModel, guid, buildBrand []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T128(isGuidFromFileNull, isGuidAvailable, isGuidChanged bool, guidFlag uint32, buildModel, guid, buildBrand []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x128)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)

--- a/internal/tlv/t141.go
+++ b/internal/tlv/t141.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T141(simInfo, apn []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x141)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)
 			w.WriteBytesShort(simInfo)
 			w.WriteUInt16(2) // network type wifi

--- a/internal/tlv/t141.go
+++ b/internal/tlv/t141.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T141(simInfo, apn []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T141(simInfo, apn []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x141)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)

--- a/internal/tlv/t142.go
+++ b/internal/tlv/t142.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T142(apkId string) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T142(apkId string) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x142)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)

--- a/internal/tlv/t142.go
+++ b/internal/tlv/t142.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T142(apkId string) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x142)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)
 			w.WriteTlvLimitedSize([]byte(apkId), 32)
 		}))

--- a/internal/tlv/t143.go
+++ b/internal/tlv/t143.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T143(arr []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T143(arr []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x143)
 		w.WriteBytesShort(arr)
 	})

--- a/internal/tlv/t144.go
+++ b/internal/tlv/t144.go
@@ -9,17 +9,17 @@ func T144(
 	isGuidFromFileNull, isGuidAvailable, isGuidChanged bool,
 	guidFlag uint32,
 	buildModel, guid, buildBrand, tgtgtKey []byte,
-) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x144)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.EncryptAndWrite(tgtgtKey, binary.NewWriterF(func(w *binary.Writer) {
 				w.WriteUInt16(5)
-				w.Write(T109(imei))
-				w.Write(T52D(devInfo))
-				w.Write(T124(osType, osVersion, simInfo, apn))
-				w.Write(T128(isGuidFromFileNull, isGuidAvailable, isGuidChanged, guidFlag, buildModel, guid, buildBrand))
-				w.Write(T16E(buildModel))
+				w.WriteAndClose(T109(imei))
+				w.WriteAndClose(T52D(devInfo))
+				w.WriteAndClose(T124(osType, osVersion, simInfo, apn))
+				w.WriteAndClose(T128(isGuidFromFileNull, isGuidAvailable, isGuidChanged, guidFlag, buildModel, guid, buildBrand))
+				w.WriteAndClose(T16E(buildModel))
 			}))
 		}))
 	})

--- a/internal/tlv/t144.go
+++ b/internal/tlv/t144.go
@@ -12,7 +12,7 @@ func T144(
 ) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x144)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.EncryptAndWrite(tgtgtKey, binary.NewWriterF(func(w *binary.Writer) {
 				w.WriteUInt16(5)
 				w.Write(T109(imei))

--- a/internal/tlv/t145.go
+++ b/internal/tlv/t145.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T145(guid []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x145)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(guid)
 		}))
 	})

--- a/internal/tlv/t145.go
+++ b/internal/tlv/t145.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T145(guid []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T145(guid []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x145)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(guid)

--- a/internal/tlv/t147.go
+++ b/internal/tlv/t147.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T147(appId uint32, apkVersionName, apkSignatureMd5 []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x147)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(appId)
 			w.WriteTlvLimitedSize(apkVersionName, 32)
 			w.WriteTlvLimitedSize(apkSignatureMd5, 32)

--- a/internal/tlv/t147.go
+++ b/internal/tlv/t147.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T147(appId uint32, apkVersionName, apkSignatureMd5 []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T147(appId uint32, apkVersionName, apkSignatureMd5 []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x147)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(appId)

--- a/internal/tlv/t154.go
+++ b/internal/tlv/t154.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T154(seq uint16) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T154(seq uint16) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x154)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(uint32(seq))

--- a/internal/tlv/t154.go
+++ b/internal/tlv/t154.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T154(seq uint16) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x154)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(uint32(seq))
 		}))
 	})

--- a/internal/tlv/t16.go
+++ b/internal/tlv/t16.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T16(ssoVersion, appId, subAppId uint32, guid, apkId, apkVersionName, apkSign []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T16(ssoVersion, appId, subAppId uint32, guid, apkId, apkVersionName, apkSign []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x16)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(ssoVersion)

--- a/internal/tlv/t16.go
+++ b/internal/tlv/t16.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T16(ssoVersion, appId, subAppId uint32, guid, apkId, apkVersionName, apkSign []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x16)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(ssoVersion)
 			w.WriteUInt32(appId)
 			w.WriteUInt32(subAppId)

--- a/internal/tlv/t166.go
+++ b/internal/tlv/t166.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T166(imageType byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x166)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(imageType)
 		}))
 	})

--- a/internal/tlv/t166.go
+++ b/internal/tlv/t166.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T166(imageType byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T166(imageType byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x166)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(imageType)

--- a/internal/tlv/t16a.go
+++ b/internal/tlv/t16a.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T16A(arr []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T16A(arr []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x16A)
 		w.WriteBytesShort(arr)
 	})

--- a/internal/tlv/t16e.go
+++ b/internal/tlv/t16e.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T16E(buildModel []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T16E(buildModel []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x16e)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(buildModel)

--- a/internal/tlv/t16e.go
+++ b/internal/tlv/t16e.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T16E(buildModel []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x16e)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(buildModel)
 		}))
 	})

--- a/internal/tlv/t174.go
+++ b/internal/tlv/t174.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T174(data []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T174(data []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x174)
 		w.WriteBytesShort(data)
 	})

--- a/internal/tlv/t177.go
+++ b/internal/tlv/t177.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T177(buildTime uint32, sdkVersion string) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x177)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(0x01)
 			w.WriteUInt32(buildTime)
 			w.WriteBytesShort([]byte(sdkVersion))

--- a/internal/tlv/t177.go
+++ b/internal/tlv/t177.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T177(buildTime uint32, sdkVersion string) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T177(buildTime uint32, sdkVersion string) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x177)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(0x01)

--- a/internal/tlv/t17a.go
+++ b/internal/tlv/t17a.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T17A(value int32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x17a)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(uint32(value))
 		}))
 	})

--- a/internal/tlv/t17a.go
+++ b/internal/tlv/t17a.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T17A(value int32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T17A(value int32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x17a)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(uint32(value))

--- a/internal/tlv/t17c.go
+++ b/internal/tlv/t17c.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T17C(code string) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T17C(code string) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x17c)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteStringShort(code)

--- a/internal/tlv/t17c.go
+++ b/internal/tlv/t17c.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T17C(code string) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x17c)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteStringShort(code)
 		}))
 	})

--- a/internal/tlv/t18.go
+++ b/internal/tlv/t18.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T18(appId uint32, uin uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T18(appId uint32, uin uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x18)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)

--- a/internal/tlv/t18.go
+++ b/internal/tlv/t18.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T18(appId uint32, uin uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x18)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)
 			w.WriteUInt32(1536)
 			w.WriteUInt32(appId)

--- a/internal/tlv/t187.go
+++ b/internal/tlv/t187.go
@@ -9,7 +9,7 @@ import (
 func T187(macAddress []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x187)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			h := md5.Sum(macAddress)
 			w.Write(h[:])
 		}))

--- a/internal/tlv/t187.go
+++ b/internal/tlv/t187.go
@@ -6,8 +6,8 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T187(macAddress []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T187(macAddress []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x187)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			h := md5.Sum(macAddress)

--- a/internal/tlv/t188.go
+++ b/internal/tlv/t188.go
@@ -6,8 +6,8 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T188(androidId []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T188(androidId []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x188)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			h := md5.Sum(androidId)

--- a/internal/tlv/t188.go
+++ b/internal/tlv/t188.go
@@ -9,7 +9,7 @@ import (
 func T188(androidId []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x188)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			h := md5.Sum(androidId)
 			w.Write(h[:])
 		}))

--- a/internal/tlv/t191.go
+++ b/internal/tlv/t191.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T191(k byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T191(k byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x191)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(k)

--- a/internal/tlv/t191.go
+++ b/internal/tlv/t191.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T191(k byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x191)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(k)
 		}))
 	})

--- a/internal/tlv/t193.go
+++ b/internal/tlv/t193.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T193(ticket string) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x193)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write([]byte(ticket))
 		}))
 	})

--- a/internal/tlv/t193.go
+++ b/internal/tlv/t193.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T193(ticket string) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T193(ticket string) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x193)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write([]byte(ticket))

--- a/internal/tlv/t194.go
+++ b/internal/tlv/t194.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T194(imsiMd5 []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T194(imsiMd5 []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x194)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(imsiMd5)

--- a/internal/tlv/t194.go
+++ b/internal/tlv/t194.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T194(imsiMd5 []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x194)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(imsiMd5)
 		}))
 	})

--- a/internal/tlv/t197.go
+++ b/internal/tlv/t197.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T197() []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T197() ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x197)
 		w.WriteBytesShort([]byte{0})
 	})

--- a/internal/tlv/t198.go
+++ b/internal/tlv/t198.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T198() []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T198() ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x198)
 		w.WriteBytesShort([]byte{0})
 	})

--- a/internal/tlv/t1b.go
+++ b/internal/tlv/t1b.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T1B(micro, version, size, margin, dpi, ecLevel, hint uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T1B(micro, version, size, margin, dpi, ecLevel, hint uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x1B)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(micro)

--- a/internal/tlv/t1b.go
+++ b/internal/tlv/t1b.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T1B(micro, version, size, margin, dpi, ecLevel, hint uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x1B)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(micro)
 			w.WriteUInt32(version)
 			w.WriteUInt32(size)

--- a/internal/tlv/t1d.go
+++ b/internal/tlv/t1d.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T1D(miscBitmap uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T1D(miscBitmap uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x1D)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(1)

--- a/internal/tlv/t1d.go
+++ b/internal/tlv/t1d.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T1D(miscBitmap uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x1D)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(1)
 			w.WriteUInt32(miscBitmap)
 			w.WriteUInt32(0)

--- a/internal/tlv/t1f.go
+++ b/internal/tlv/t1f.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T1F(isRoot bool, osName, osVersion, simOperatorName, apn []byte, networkType uint16) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T1F(isRoot bool, osName, osVersion, simOperatorName, apn []byte, networkType uint16) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x1F)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(func() byte {

--- a/internal/tlv/t1f.go
+++ b/internal/tlv/t1f.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T1F(isRoot bool, osName, osVersion, simOperatorName, apn []byte, networkType uint16) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x1F)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteByte(func() byte {
 				if isRoot {
 					return 1

--- a/internal/tlv/t2.go
+++ b/internal/tlv/t2.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T2(result string, sign []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T2(result string, sign []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x02)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)

--- a/internal/tlv/t2.go
+++ b/internal/tlv/t2.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T2(result string, sign []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x02)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)
 			w.WriteStringShort(result)
 			w.WriteBytesShort(sign)

--- a/internal/tlv/t202.go
+++ b/internal/tlv/t202.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T202(wifiBSSID, wifiSSID []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x202)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteTlvLimitedSize(wifiBSSID, 16)
 			w.WriteTlvLimitedSize(wifiSSID, 32)
 		}))

--- a/internal/tlv/t202.go
+++ b/internal/tlv/t202.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T202(wifiBSSID, wifiSSID []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T202(wifiBSSID, wifiSSID []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x202)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteTlvLimitedSize(wifiBSSID, 16)

--- a/internal/tlv/t33.go
+++ b/internal/tlv/t33.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T33(guid []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T33(guid []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x33)
 		w.WriteBytesShort(guid)
 	})

--- a/internal/tlv/t35.go
+++ b/internal/tlv/t35.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T35(productType uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x35)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(productType)
 		}))
 	})

--- a/internal/tlv/t35.go
+++ b/internal/tlv/t35.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T35(productType uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T35(productType uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x35)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(productType)

--- a/internal/tlv/t400.go
+++ b/internal/tlv/t400.go
@@ -6,8 +6,8 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T400(g []byte, uin int64, guid, dpwd []byte, j2, j3 int64, randSeed []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T400(g []byte, uin int64, guid, dpwd []byte, j2, j3 int64, randSeed []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x400)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.EncryptAndWrite(g, binary.NewWriterF(func(w *binary.Writer) {

--- a/internal/tlv/t400.go
+++ b/internal/tlv/t400.go
@@ -9,7 +9,7 @@ import (
 func T400(g []byte, uin int64, guid, dpwd []byte, j2, j3 int64, randSeed []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x400)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.EncryptAndWrite(g, binary.NewWriterF(func(w *binary.Writer) {
 				w.WriteUInt16(1) // version
 				w.WriteUInt64(uint64(uin))

--- a/internal/tlv/t401.go
+++ b/internal/tlv/t401.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T401(d []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T401(d []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x401)
 		w.WriteBytesShort(d)
 	})

--- a/internal/tlv/t511.go
+++ b/internal/tlv/t511.go
@@ -7,14 +7,14 @@ import (
 	"github.com/Mrs4s/MiraiGo/binary"
 )
 
-func T511(domains []string) []byte {
+func T511(domains []string) ([]byte, func()) {
 	var arr2 []string
 	for _, d := range domains {
 		if d != "" {
 			arr2 = append(arr2, d)
 		}
 	}
-	return binary.NewWriterF(func(w *binary.Writer) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x511)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(uint16(len(arr2)))

--- a/internal/tlv/t511.go
+++ b/internal/tlv/t511.go
@@ -16,7 +16,7 @@ func T511(domains []string) []byte {
 	}
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x511)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(uint16(len(arr2)))
 			for _, d := range arr2 {
 				indexOf := strings.Index(d, "(")

--- a/internal/tlv/t516.go
+++ b/internal/tlv/t516.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T516() []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T516() ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x516)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(0)

--- a/internal/tlv/t516.go
+++ b/internal/tlv/t516.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T516() []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x516)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(0)
 		}))
 	})

--- a/internal/tlv/t521.go
+++ b/internal/tlv/t521.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T521(i uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T521(i uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x521)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(i)

--- a/internal/tlv/t521.go
+++ b/internal/tlv/t521.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T521(i uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x521)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt32(i)
 			w.WriteUInt16(0)
 		}))

--- a/internal/tlv/t525.go
+++ b/internal/tlv/t525.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T525(t536 []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T525(t536 []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x525)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)

--- a/internal/tlv/t525.go
+++ b/internal/tlv/t525.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T525(t536 []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x525)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(1)
 			w.Write(t536)
 		}))

--- a/internal/tlv/t52d.go
+++ b/internal/tlv/t52d.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T52D(devInfo []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T52D(devInfo []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x52d)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(devInfo)

--- a/internal/tlv/t52d.go
+++ b/internal/tlv/t52d.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T52D(devInfo []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x52d)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(devInfo)
 		}))
 	})

--- a/internal/tlv/t536.go
+++ b/internal/tlv/t536.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T536(loginExtraData []byte) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x536)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.Write(loginExtraData)
 		}))
 	})

--- a/internal/tlv/t545.go
+++ b/internal/tlv/t545.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T545(imei []byte) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T545(imei []byte) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x108)
 		w.WriteBytesShort(imei)
 	})

--- a/internal/tlv/t8.go
+++ b/internal/tlv/t8.go
@@ -5,7 +5,7 @@ import "github.com/Mrs4s/MiraiGo/binary"
 func T8(localId uint32) []byte {
 	return binary.NewWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x8)
-		w.WriteBytesShort(binary.NewWriterF(func(w *binary.Writer) {
+		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)
 			w.WriteUInt32(localId)
 			w.WriteUInt16(0)

--- a/internal/tlv/t8.go
+++ b/internal/tlv/t8.go
@@ -2,8 +2,8 @@ package tlv
 
 import "github.com/Mrs4s/MiraiGo/binary"
 
-func T8(localId uint32) []byte {
-	return binary.NewWriterF(func(w *binary.Writer) {
+func T8(localId uint32) ([]byte, func()) {
+	return binary.OpenWriterF(func(w *binary.Writer) {
 		w.WriteUInt16(0x8)
 		w.WriteBytesShortAndClose(binary.OpenWriterF(func(w *binary.Writer) {
 			w.WriteUInt16(0)


### PR DESCRIPTION
将 OpenWriterF 应用到更多函数以减少内存碎片。在树莓派`zero w`下测试，这样处理之后虚拟内存总量并无显著变化，但`RSS`有所增加，对应于分配了更多的`Writer`在池中以备不时之需，这应该是一件好事。

|  项目  |  old  |  new  |
|  ----  | ----  | ----  |
| VmPeak  | 825116 kB | 825120 kB |
| VmSize  | 823964 kB | 823968 kB |
| VmHWM  | 22920 kB | 22880 kB |
| VmRSS  | 22164 kB| 21940 kB |
| RssAnon  | 5152 kB | 5064 kB |
| RssFile  | 16088 kB | 15960 kB |
| RssShmem  | 924 kB | 916 kB |
