### PR TITLE
fix ToGroupUin, ToGroupCode

### DIFF
--- a/utils/group.go
+++ b/utils/group.go
@@ -15,8 +15,12 @@ func ToGroupUin(groupCode int64) int64 {
 		left += 2147 - 157
 	case left >= 210 && left <= 309:
 		left += 4100 - 210
-	case left >= 310 && left <= 499:
+	case left >= 310 && left <= 335:
 		left += 3800 - 310
+	case left >= 336 && left <= 386:
+		left += 2265
+	case left >= 387 && left <= 499:
+		left += 3490
 	}
 	return left*1000000 + groupCode%1000000
 }
@@ -24,19 +28,21 @@ func ToGroupUin(groupCode int64) int64 {
 func ToGroupCode(groupUin int64) int64 {
 	left := groupUin / 1000000
 	switch {
-	case left >= 0+202 && left <= 10+202:
+	case left >= 202 && left <= 212:
 		left -= 202
-	case left >= 11+480-11 && left <= 19+480-11:
+	case left >= 480 && left <= 488:
 		left -= 480 - 11
-	case left >= 20+2100-20 && left <= 66+2100-20:
+	case left >= 2100 && left <= 2146:
 		left -= 2100 - 20
-	case left >= 67+2010-67 && left <= 156+2010-67:
+	case left >= 2010 && left <= 2099:
 		left -= 2010 - 67
-	case left >= 157+2147-157 && left <= 209+2147-157:
+	case left >= 2147 && left <= 2199:
 		left -= 2147 - 157
-	case left >= 210+4100-210 && left <= 309+4100-210:
+	case left >= 2600 && left <= 2651:
+		left -= 2265
+	case left >= 4100 && left <= 4199:
 		left -= 4100 - 210
-	case left >= 310+3800-310 && left <= 499+3800-310:
+	case left >= 3800 && left <= 3989:
 		left -= 3800 - 310
 	}
 	return left*1000000 + groupUin%1000000


### PR DESCRIPTION
修复：`uin: 2613014270, code: 348014270`

用410个群验证，每个分支都走过，计算没问题