### PR TITLE
fix: 合并转发

### DIFF
--- a/client/multimsg.go
+++ b/client/multimsg.go
@@ -225,6 +225,6 @@ func forwardDisplay(resID, fileName, preview, summary string) string {
 	sb.WriteString(`<hr></hr><summary size="26" color="#808080">`)
 	sb.WriteString(summary)
 	// todo: 私聊的聊天记录？
-	sb.WriteString(`</summary></item><source name="群聊的聊天记录"></source></msg>`)
+	sb.WriteString(`</summary></item><source name="聊天记录"></source></msg>`)
 	return sb.String()
 }


### PR DESCRIPTION
似在commit e287cbfabd0438955a7415a430f3ebfb3762cfca的时候复制粘贴错了 xml格式不符导致合并转发发送失败?
228行 群聊的聊天记录 改成聊天记录能发了