### PR TITLE
genLongTemplate 非ASCII字符串长度计数错误

### DIFF
--- a/client/global.go
+++ b/client/global.go
@@ -307,8 +307,8 @@ func genForwardTemplate(resID, preview, summary string, ts int64, items []*msg.P
 
 func genLongTemplate(resID, brief string, ts int64) *message.ServiceElement {
 	limited := func() string {
-		if len(brief) > 30 {
-			return brief[:30] + "…"
+		if ss := []rune(brief); len(ss) > 30 {
+			return string(ss[:30]) + "…"
 		}
 		return brief
 	}()


### PR DESCRIPTION
一个字切成半个啦😭
貌似[#1295](https://github.com/Mrs4s/go-cqhttp/issues/1295)也被修复了?