### PR TITLE
fix: 修复空指针可能导致panic的问题

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -180,6 +180,9 @@ func (c *QQClient) sendAndWait(seq uint16, pkt []byte, params ...network.Request
 	for {
 		select {
 		case rsp := <-ch:
+			if rsp.Response == nil {
+				return nil, errors.New("Response is nil")
+			}
 			return rsp.Response, rsp.Error
 		case <-time.After(time.Second * 15):
 			retry++

--- a/client/network.go
+++ b/client/network.go
@@ -180,7 +180,7 @@ func (c *QQClient) sendAndWait(seq uint16, pkt []byte, params ...network.Request
 	for {
 		select {
 		case rsp := <-ch:
-			if rsp.Response == nil {
+			if rsp.Response == nil && rsp.Error == nil {
 				return nil, errors.New("Response is nil")
 			}
 			return rsp.Response, rsp.Error

--- a/client/system_msg.go
+++ b/client/system_msg.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"github.com/Mrs4s/MiraiGo/client/internal/network"
 	"github.com/Mrs4s/MiraiGo/client/pb/structmsg"
 	"github.com/Mrs4s/MiraiGo/internal/proto"
@@ -48,9 +47,6 @@ func (c *QQClient) GetGroupSystemMessages() (*GroupSystemMessages, error) {
 	i, err := c.sendAndWait(c.buildSystemMsgNewGroupPacket(false))
 	if err != nil {
 		return nil, err
-	}
-	if i == nil {
-		return nil, errors.New("nil response")
 	}
 	msg := i.(*GroupSystemMessages)
 	i, err = c.sendAndWait(c.buildSystemMsgNewGroupPacket(true))

--- a/client/system_msg.go
+++ b/client/system_msg.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"github.com/Mrs4s/MiraiGo/client/internal/network"
 	"github.com/Mrs4s/MiraiGo/client/pb/structmsg"
 	"github.com/Mrs4s/MiraiGo/internal/proto"
@@ -47,6 +48,9 @@ func (c *QQClient) GetGroupSystemMessages() (*GroupSystemMessages, error) {
 	i, err := c.sendAndWait(c.buildSystemMsgNewGroupPacket(false))
 	if err != nil {
 		return nil, err
+	}
+	if i == nil {
+		return nil, errors.New("nil response")
 	}
 	msg := i.(*GroupSystemMessages)
 	i, err = c.sendAndWait(c.buildSystemMsgNewGroupPacket(true))


### PR DESCRIPTION

> panic: interface conversion: interface {} is nil, not *client.GroupSystemMessages
> 
> goroutine 31 [running]:
> github.com/Mrs4s/MiraiGo/client.(*QQClient).GetGroupSystemMessages(0x19919ab95fdf8?)
>         C:/Users/atom/go/pkg/mod/github.com/!mrs4s/!mirai!go@v0.0.0-20220720124026-5c0e2c5773de/client/system_msg.go:51 +0x305
