### PR TITLE
修复 MacOS 协议

### DIFF
--- a/client/internal/auth/auth.go
+++ b/client/internal/auth/auth.go
@@ -77,8 +77,8 @@ func (i Protocol) Version() *AppVersion {
 	case MacOS:
 		return &AppVersion{
 			ApkId:           "com.tencent.minihd.qq",
-			AppId:           537064315,
-			SubAppId:        537064315,
+			AppId:           537128930,
+			SubAppId:        537128930,
 			SortVersionName: "5.8.9",
 			BuildTime:       1595836208,
 			ApkSign:         []byte{170, 57, 120, 244, 31, 217, 111, 249, 145, 74, 102, 158, 24, 100, 116, 199},


### PR DESCRIPTION
新 SubAppId 来自 https://github.com/takayama-lily/oicq/pull/418
应该可以解决登录失败的问题 https://github.com/Mrs4s/go-cqhttp/issues/1646