### PR TITLE
试图修复 IPad 协议登录

### DIFF
--- a/client/internal/auth/auth.go
+++ b/client/internal/auth/auth.go
@@ -62,9 +62,9 @@ func (i Protocol) Version() *AppVersion {
 	case IPad:
 		return &AppVersion{
 			ApkId:           "com.tencent.minihd.qq",
-			AppId:           537097188,
-			SubAppId:        537097188,
-			SortVersionName: "8.8.35",
+			AppId:           537118796,
+			SubAppId:        537118796,
+			SortVersionName: "5.9.3",
 			BuildTime:       1595836208,
 			ApkSign:         []byte{170, 57, 120, 244, 31, 217, 111, 249, 145, 74, 102, 158, 24, 100, 116, 199},
 			SdkVersion:      "6.0.0.2433",


### PR DESCRIPTION
试图修复 IPad 协议登录问题 https://github.com/Mrs4s/MiraiGo/issues/298 ，更新的 ID 和 Version 来源于 [OICQ](https://github.com/takayama-lily/oicq/blob/main/lib/core/device.ts#L163)  。