### PR TITLE
修正GenIMEI

### DIFF
--- a/client/global.go
+++ b/client/global.go
@@ -92,14 +92,14 @@ func GenIMEI() string {
 	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 14; i++ { // generating all the base digits
 		toAdd := randGen.Intn(10)
+		fmt.Fprintf(&final, "%d", toAdd) // printing them here!
 		if (i+1)%2 == 0 { // special proc for every 2nd one
 			toAdd *= 2
 			if toAdd >= 10 {
 				toAdd = (toAdd % 10) + 1
 			}
 		}
-		sum += toAdd
-		fmt.Fprintf(&final, "%d", toAdd) // and even printing them here!
+		sum += toAdd // and even add them here!
 	}
 	ctrlDigit := (sum * 9) % 10 // calculating the control digit
 	fmt.Fprintf(&final, "%d", ctrlDigit)


### PR DESCRIPTION
依照[Luhn algorithm - Wikipedia](https://en.wikipedia.org/wiki/Luhn_algorithm)中的描述：
![AZMPMN`955YCI6Q0UAZO0`M](https://user-images.githubusercontent.com/26300331/224641429-396bd824-a8c7-4952-91af-d648ae56e68b.png)
`IMEI`编码的拼接应当基于被用于校验的源数据，而非在校验位计算过程中被用于累加的中间量