### PR TITLE
增加头部SsoSecureInfo代码实现

### DIFF
--- a/client/pb/data.pb.go
+++ b/client/pb/data.pb.go
@@ -3,6 +3,25 @@
 
 package pb
 
+type SSOReserveField struct {
+	Flag        int32          `protobuf:"varint,9,opt"`
+	Qimei       string         `protobuf:"bytes,12,opt"`
+	NewconnFlag int32          `protobuf:"varint,14,opt"`
+	Uid         string         `protobuf:"bytes,16,opt"`
+	Imsi        int32          `protobuf:"varint,18,opt"`
+	NetworkType int32          `protobuf:"varint,19,opt"`
+	IpStackType int32          `protobuf:"varint,20,opt"`
+	MessageType int32          `protobuf:"varint,21,opt"`
+	SecInfo     *SsoSecureInfo `protobuf:"bytes,24,opt"`
+	SsoIpOrigin int32          `protobuf:"varint,28,opt"`
+}
+
+type SsoSecureInfo struct {
+	SecSig         []byte `protobuf:"bytes,1,opt"`
+	SecDeviceToken []byte `protobuf:"bytes,2,opt"`
+	SecExtra       []byte `protobuf:"bytes,3,opt"`
+}
+
 type DeviceInfo struct {
 	Bootloader   string `protobuf:"bytes,1,opt"`
 	ProcVersion  string `protobuf:"bytes,2,opt"`

--- a/client/pb/data.proto
+++ b/client/pb/data.proto
@@ -2,6 +2,25 @@ syntax = "proto3";
 
 option go_package = "github.com/Mrs4s/MiraiGo/client/pb";
 
+message SSOReserveField {
+  int32 flag = 9;
+  string qimei = 12;
+  int32 newconn_flag = 14;
+  string uid = 16;
+  int32 imsi = 18;
+  int32 network_type = 19;
+  int32 ip_stack_type = 20;
+  int32 message_type = 21;
+  SsoSecureInfo sec_info = 24;
+  int32 sso_ip_origin = 28;
+}
+
+message SsoSecureInfo {
+  bytes sec_sig = 1;
+  bytes sec_device_token = 2;
+  bytes sec_extra = 3;
+}
+
 message DeviceInfo {
   string bootloader = 1;
   string procVersion = 2;

--- a/wrapper/codec.go
+++ b/wrapper/codec.go
@@ -1,3 +1,7 @@
 package wrapper
 
 var DandelionEnergy func(uint64, string, string, []byte) ([]byte, error)
+
+var FekitGetSign func(uint64, string, string, string, []byte) ([]byte, []byte, []byte, error)
+
+var AllowSignSendMsg func() bool


### PR DESCRIPTION
用于修复登录45（登录失败，请通过问题反馈联系），和发送群/私聊消息显示假风控