### PR TITLE
提供外部可调用的函数 'SendSsoPacket' 供提交回调给签名服务器

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -310,6 +310,13 @@ func (c *QQClient) sendAndWaitDynamic(seq uint16, pkt []byte) ([]byte, error) {
 	}
 }
 
+// SendSsoPacket
+// 发送签名回调包给服务器并获取返回结果供提交
+func (c *QQClient) SendSsoPacket(cmd string, body []byte) ([]byte, error) {
+	seq, data := c.uniPacket(cmd, body)
+	return c.sendAndWaitDynamic(seq, data)
+}
+
 // plannedDisconnect 计划中断线事件
 func (c *QQClient) plannedDisconnect(_ *network.TCPClient) {
 	c.debug("planned disconnect.")


### PR DESCRIPTION
当前 go-cqhttp 使用的签名服务器新版本需要提交签名回调等，刷新 token 需要提交回调包，提交的包需要经过签名打包并发送给服务器获取返回值，将返回值提交给签名服务器  (https://github.com/fuqiuluo/unidbg-fetch-qsign/discussions/98#discussioncomment-6361993) ，自测在使用此函数后可以正常刷新，后续没有再丢失 token 