### PR TITLE
修复 因为媒体服务器不存在 而导致的 panic - 数组溢出 ,并且新增媒体服务器提示状态.

### DIFF
--- a/client/internal/highway/highway.go
+++ b/client/internal/highway/highway.go
@@ -224,6 +224,28 @@ func (s *Session) connect(addr Addr) (persistConn, error) {
 func (s *Session) nextAddr() Addr {
 	s.addrMu.Lock()
 	defer s.addrMu.Unlock()
+
+	if len(s.SsoAddr) == 0 {
+		//fmt.Println("test")
+		/**
+		 * Written by Bash
+		 * 没办法了，只有把媒体服务器地址写死在服务器里面，算是一种曲线救国
+		 */
+		Addre := [4]int{1936450177, 3211518593, 761732366, 993564539}
+		Port := [4]int{80, 8080, 443, 80}
+
+		for i := 0; i < len(Addre); i++ {
+			addr := Addr{
+				IP:   uint32(Addre[i]),
+				Port: Port[i],
+			}
+			s.SsoAddr = append(s.SsoAddr, addr)
+		}
+
+		//s.AppendAddr(1153745079,8080)
+		//fmt.Println(len(s.SsoAddr))
+	}
+
 	addr := s.SsoAddr[s.idx]
 	s.idx = (s.idx + 1) % len(s.SsoAddr)
 	return addr

--- a/client/internal/highway/highway.go
+++ b/client/internal/highway/highway.go
@@ -224,28 +224,6 @@ func (s *Session) connect(addr Addr) (persistConn, error) {
 func (s *Session) nextAddr() Addr {
 	s.addrMu.Lock()
 	defer s.addrMu.Unlock()
-
-	if len(s.SsoAddr) == 0 {
-		//fmt.Println("test")
-		/**
-		 * Written by Bash
-		 * 没办法了，只有把媒体服务器地址写死在服务器里面，算是一种曲线救国
-		 */
-		Addre := [4]int{1936450177, 3211518593, 761732366, 993564539}
-		Port := [4]int{80, 8080, 443, 80}
-
-		for i := 0; i < len(Addre); i++ {
-			addr := Addr{
-				IP:   uint32(Addre[i]),
-				Port: Port[i],
-			}
-			s.SsoAddr = append(s.SsoAddr, addr)
-		}
-
-		//s.AppendAddr(1153745079,8080)
-		//fmt.Println(len(s.SsoAddr))
-	}
-
 	addr := s.SsoAddr[s.idx]
 	s.idx = (s.idx + 1) % len(s.SsoAddr)
 	return addr

--- a/client/network.go
+++ b/client/network.go
@@ -66,6 +66,8 @@ func (c *QQClient) ConnectionQualityTest() *ConnectionQualityInfo {
 				c.error("test srv server latency error: %v", err)
 				r.SrvServerLatency = 9999
 			}
+		} else {
+			r.SrvServerPacketLoss = -1
 		}
 	}()
 	go func() {

--- a/client/network.go
+++ b/client/network.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"net"
 	"net/netip"
@@ -75,7 +74,6 @@ func (c *QQClient) ConnectionQualityTest() *ConnectionQualityInfo {
 
 			content := ""
 			for i := 0; i < c.highwaySession.AddrLength(); i++ {
-				fmt.Println(c.highwaySession.SsoAddr[i].String())
 				content += c.highwaySession.SsoAddr[i].String() + "\n"
 			}
 			file, _ := os.OpenFile("addr_server.txt", os.O_CREATE|os.O_RDWR, 0666)
@@ -85,7 +83,6 @@ func (c *QQClient) ConnectionQualityTest() *ConnectionQualityInfo {
 			file.Write([]byte(content))
 
 		} else {
-			fmt.Println("test")
 			r.SrvServerLatency = -1
 
 			file, _ := os.Open("addr_server.txt")


### PR DESCRIPTION
修复 因为媒体服务器不存在 而导致的 panic - 数组溢出 ,并且新增媒体服务器提示状态
对应Issue:
Mrs4s/go-cqhttp#2517
Mrs4s/go-cqhttp#2521

现在可以和  Mrs4s/go-cqhttp#2522 一起配合检测媒体服务器是否存在.