### PR TITLE
fix: 修复 SsoAddr 地址为空导致报错的问题

### DIFF
--- a/client/multimsg.go
+++ b/client/multimsg.go
@@ -313,6 +313,13 @@ func (builder *ForwardMessageBuilder) Main(m *message.ForwardMessage) *message.F
 		Sum:       bodyHash[:],
 		Size:      int64(len(body)),
 	}
+
+	if c.highwaySession.AddrLength() == 0 {
+		c.uploadGroupOrGuildImage(message.Source{
+			SourceType: message.SourceGroup,
+			PrimaryID:  builder.groupCode,
+		}, bytes.NewReader(make([]byte, 8)))
+	}
 	_, err = c.highwaySession.Upload(input)
 	if err != nil {
 		return nil


### PR DESCRIPTION
修复 ForwardMessageBuilder.Main 函数调用highwaySession.Upload 时， nextAddr函数报错 runtime error: index out of range [0] with length 0；
说明：通过上传一张空图片获取 SsoAddr 地址